### PR TITLE
feat: connect signup forms to auth

### DIFF
--- a/contractor-signup.html
+++ b/contractor-signup.html
@@ -287,29 +287,47 @@
       // attest: !!document.getElementById("attest")?.checked,
     };
 
+    const password = document.getElementById("password").value;
     const licenseFile = document.getElementById("license")?.files?.[0] || null;
 
     try {
-      // 1) Try upload (will skip if no session)
+      // 1) Create auth user
+      const { data: signData, error: signErr } = await supabase.auth.signUp({
+        email: payload.email,
+        password,
+        options: { data: { role: payload.role } }
+      });
+      if (signErr || !signData.user) {
+        showAlert("error", signErr?.message || "Sign up failed.");
+        return;
+      }
+      const authUserId = signData.user.id;
+
+      // 2) Try upload (will skip if no session)
       const up = await maybeUploadToApplicationsBucket(licenseFile);
       const license_url = up.path || null; // store path in applications.license_url
 
-      // 2) Insert application
+      // 3) Insert application
       const { error } = await supabase.from("applications").insert([{
         ...payload,
+        auth_user_id: authUserId,
         license_url  // ensure your table has this column
       }]);
       if (error) throw error;
 
-      // 3) UI success
+      // 4) UI success
       form.classList.add("hidden");
       successState.classList.remove("hidden");
 
+      const needsConfirm = !signData.session;
+      let msg;
       if (up.skipped) {
-        showAlert("info", "Application received. You can upload documents after we approve and invite you to log in.");
+        msg = "Application received. You can upload documents after we approve and invite you to log in.";
       } else {
-        showAlert("success", "Application received with your document. We’ll review it shortly.");
+        msg = "Application received with your document. We’ll review it shortly.";
       }
+      if (needsConfirm) msg += " Please check your email to confirm your account.";
+      showAlert(up.skipped ? "info" : "success", msg);
     } catch (err) {
       console.error(err);
       showAlert("error", err?.message || "Something went wrong. Try again.");

--- a/developer-signup.html
+++ b/developer-signup.html
@@ -298,27 +298,40 @@
         companyName: document.getElementById("companyName").value.trim(),
         email: document.getElementById("email").value.trim(),
         phone: document.getElementById("phone").value.trim(),
-        // NOTE: DO NOT store this password in applications; real account is created on approval via Supabase invite
         projectType: document.getElementById("projectType").value,
         projectZips: document.getElementById("zips").value.trim().split(",").map(s => s.trim()),
         proofFile: document.getElementById("proof").files[0] || null,
         website: document.getElementById("website").value.trim() || null,
         linkedin: document.getElementById("linkedin").value.trim() || null
         };
+        const password = document.getElementById("password").value;
+        const role = "developer";
 
         try {
-        // Optional file upload
+        // 1) Create auth user
+        const { data: signData, error: signErr } = await supabase.auth.signUp({
+            email: payload.email,
+            password,
+            options: { data: { role } }
+        });
+        if (signErr || !signData.user) {
+            showAlert("error", signErr?.message || "Sign up failed.");
+            return;
+        }
+        const authUserId = signData.user.id;
+
+        // 2) Optional file upload (requires session)
         let proof_filename = null;
-        if (USE_STORAGE && payload.proofFile) {
+        if (USE_STORAGE && payload.proofFile && signData.session) {
             const fileName = `incoming/${crypto.randomUUID()}_${payload.proofFile.name}`;
             const { error: upErr } = await supabase.storage.from("applications").upload(fileName, payload.proofFile);
             if (upErr) throw upErr;
             proof_filename = fileName;
         }
 
-        // Insert application row
-        const { error } = await supabase.from("applications").insert([{
-            role: "developer",
+        // 3) Insert application row
+        const { error } = await supabase.from("applications").insert([{ 
+            role,
             full_name: payload.fullName,
             company_name: payload.companyName,
             email: payload.email,
@@ -327,14 +340,19 @@
             project_zips: payload.projectZips,
             website: payload.website,
             linkedin: payload.linkedin,
-            proof_filename
+            proof_filename,
+            auth_user_id: authUserId
         }]);
         if (error) throw error;
 
-        // Success UI
+        // 4) Success UI
         form.classList.add("hidden");
         successState.classList.remove("hidden");
-        showAlert("success", "Application received. We’ll review it shortly.");
+        const needsConfirm = !signData.session;
+        const msg = needsConfirm
+            ? "Application received. Check your email to confirm your account."
+            : "Application received. We’ll review it shortly.";
+        showAlert("success", msg);
 
         } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- create users via `supabase.auth.signUp` in contractor and developer signup forms
- attach returned `auth_user_id` when inserting application rows
- show confirmation email messaging and handle sign-up errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b37040393c832ba67fd2672f444fdf