### PR TITLE
Add trigger to create profile for new users

### DIFF
--- a/supabase/migrations/202308302143_handle_new_user.sql
+++ b/supabase/migrations/202308302143_handle_new_user.sql
@@ -1,0 +1,18 @@
+-- Creates a trigger function to insert a corresponding profile row for new auth.users
+create or replace function public.handle_new_user()
+returns trigger
+security definer set search_path=public as $$
+begin
+  insert into public.profiles (id, role, approved, is_paid)
+  values (new.id,
+          coalesce(new.raw_user_meta_data->>'role','contractor'),
+          false,
+          false);
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+after insert on auth.users
+for each row execute function public.handle_new_user();


### PR DESCRIPTION
## Summary
- add `public.handle_new_user` function to insert profile for each new user
- trigger `on_auth_user_created` runs after `auth.users` insert

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I https://twxpfobmjaaoaixwqcfn.supabase.co` *(HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b37045c680832bbdc37091a2b901e6