### PR TITLE
Use approved boolean for profile approval

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,7 @@
+-- Profiles table schema using `approved` boolean for account approval
+create table if not exists profiles (
+  id uuid references auth.users on delete cascade primary key,
+  role text not null,
+  approved boolean not null default false,
+  is_paid boolean not null default false
+);

--- a/login.html
+++ b/login.html
@@ -196,10 +196,10 @@
           return;
         }
 
-        // Fetch profile: role + payment status
+        // Fetch profile: role + approval/payment status
         const { data: profile, error: profErr } = await supabase
           .from("profiles")
-          .select("role, status, is_paid")
+          .select("role, approved, is_paid")
           .eq("id", userId)
           .maybeSingle();
 
@@ -209,7 +209,7 @@
         }
 
         // Gate access
-        if (!profile || profile.status !== "approved") {
+        if (!profile || !profile.approved) {
           showAlert("error", "Your application is still pending approval. You’ll hear back within 24–48 hours.");
           return;
         }

--- a/requirements.md
+++ b/requirements.md
@@ -1,0 +1,6 @@
+# Timeless Solutions Requirements
+
+## Profile Approval
+- Use an `approved` boolean column on the `profiles` table to track account approval.
+- New profiles default to `approved = false` and gain full access once an admin sets it to true.
+- The login flow queries `approved` and denies access when it is not set.


### PR DESCRIPTION
## Summary
- switch login flow to rely on `approved` boolean
- add `profiles` schema using `approved` boolean
- document approval requirements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b37049d8b0832bbfe18d5a58f75169