### PR TITLE
Sign up users on contractor and developer applications

### DIFF
--- a/contractor-signup.html
+++ b/contractor-signup.html
@@ -270,11 +270,14 @@
     if (typeof validate === "function" && !validate()) return;
 
     // Gather fields
+    const email = document.getElementById("email").value.trim();
+    const password = document.getElementById("password").value;
+    const role = "contractor";
     const payload = {
-      role: "contractor",
+      role,
       full_name: document.getElementById("fullName").value.trim(),
       company_name: document.getElementById("companyName").value.trim(),
-      email: document.getElementById("email").value.trim(),
+      email,
       phone: document.getElementById("phone").value.trim(),
       trade: document.getElementById("trade").value,
       years_in_business: Number(document.getElementById("years").value || 0),
@@ -290,15 +293,27 @@
     const licenseFile = document.getElementById("license")?.files?.[0] || null;
 
     try {
+      // Sign up user and attach role
+      const { data: signData, error: signError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: { data: { role } }
+      });
+      if (signError) throw signError;
+      const user_id = signData.user.id;
+
       // 1) Try upload (will skip if no session)
       const up = await maybeUploadToApplicationsBucket(licenseFile);
       const license_url = up.path || null; // store path in applications.license_url
 
       // 2) Insert application
-      const { error } = await supabase.from("applications").insert([{
-        ...payload,
-        license_url  // ensure your table has this column
-      }]);
+      const { error } = await supabase.from("applications").insert([
+        {
+          ...payload,
+          user_id,
+          license_url  // ensure your table has this column
+        }
+      ]);
       if (error) throw error;
 
       // 3) UI success

--- a/developer-signup.html
+++ b/developer-signup.html
@@ -292,13 +292,16 @@
         e.preventDefault();
         if (!validate()) return;
 
+        const email = document.getElementById("email").value.trim();
+        const password = document.getElementById("password").value;
+        const role = "developer";
+
         // Build payload from form
         const payload = {
         fullName: document.getElementById("fullName").value.trim(),
         companyName: document.getElementById("companyName").value.trim(),
-        email: document.getElementById("email").value.trim(),
+        email,
         phone: document.getElementById("phone").value.trim(),
-        // NOTE: DO NOT store this password in applications; real account is created on approval via Supabase invite
         projectType: document.getElementById("projectType").value,
         projectZips: document.getElementById("zips").value.trim().split(",").map(s => s.trim()),
         proofFile: document.getElementById("proof").files[0] || null,
@@ -307,18 +310,28 @@
         };
 
         try {
+        // Sign up user with role metadata
+        const { data: signData, error: signError } = await supabase.auth.signUp({
+            email,
+            password,
+            options: { data: { role } }
+        });
+        if (signError) throw signError;
+        const user_id = signData.user.id;
+
         // Optional file upload
         let proof_filename = null;
         if (USE_STORAGE && payload.proofFile) {
-            const fileName = `incoming/${crypto.randomUUID()}_${payload.proofFile.name}`;
+            const fileName = `${user_id}/${crypto.randomUUID()}_${payload.proofFile.name}`;
             const { error: upErr } = await supabase.storage.from("applications").upload(fileName, payload.proofFile);
             if (upErr) throw upErr;
             proof_filename = fileName;
         }
 
         // Insert application row
-        const { error } = await supabase.from("applications").insert([{
-            role: "developer",
+        const { error } = await supabase.from("applications").insert([{ 
+            user_id,
+            role,
             full_name: payload.fullName,
             company_name: payload.companyName,
             email: payload.email,


### PR DESCRIPTION
## Summary
- Create Supabase auth users during contractor and developer signups
- Use the created user's ID when inserting application records

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3736b8228832bb0ec7895e3cc0b66