### PR TITLE
Add role-based dashboards and redirect after login

### DIFF
--- a/contractor-dashboard.html
+++ b/contractor-dashboard.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Timeless Solutions — Contractor Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root { --accent:#f5c400; }
+    body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji"; }
+    .ts-accent { color: #1b1b1b; background: var(--accent); }
+  </style>
+</head>
+<body class="min-h-full bg-neutral-50 text-neutral-900">
+  <div class="max-w-4xl mx-auto p-6">
+    <header class="flex items-center gap-3 mb-6">
+      <div class="h-12 w-12 rounded-xl ts-accent grid place-items-center font-bold">TS</div>
+      <h1 class="text-2xl font-semibold">Contractor Dashboard</h1>
+    </header>
+
+    <!-- Ad Placeholder -->
+    <div class="my-4 h-32 w-full border-2 border-dashed border-neutral-300 rounded-lg flex items-center justify-center text-neutral-500">
+      Ad space
+    </div>
+
+    <p class="text-neutral-700">Welcome to the contractor dashboard. Content coming soon.</p>
+  </div>
+</body>
+</html>

--- a/developer-dashboard.html
+++ b/developer-dashboard.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Timeless Solutions — Developer Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root { --accent:#f5c400; }
+    body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji","Segoe UI Emoji"; }
+    .ts-accent { color: #1b1b1b; background: var(--accent); }
+  </style>
+</head>
+<body class="min-h-full bg-neutral-50 text-neutral-900">
+  <div class="max-w-4xl mx-auto p-6">
+    <header class="flex items-center gap-3 mb-6">
+      <div class="h-12 w-12 rounded-xl ts-accent grid place-items-center font-bold">TS</div>
+      <h1 class="text-2xl font-semibold">Developer Dashboard</h1>
+    </header>
+
+    <!-- Ad Placeholder -->
+    <div class="my-4 h-32 w-full border-2 border-dashed border-neutral-300 rounded-lg flex items-center justify-center text-neutral-500">
+      Ad space
+    </div>
+
+    <p class="text-neutral-700">Welcome to the developer dashboard. Content coming soon.</p>
+  </div>
+</body>
+</html>

--- a/login.html
+++ b/login.html
@@ -221,11 +221,13 @@
         }
 
         // ✅ Success
-        showAlert("success", `Welcome back, ${profile.role}! You’re cleared for access.`);
+        showAlert("success", `Welcome back, ${profile.role}! Redirecting...`);
 
-        // TODO: Redirect to role dashboard once built
-        // if (profile.role === "developer") window.location.href = "developer-dashboard.html";
-        // else window.location.href = "contractor-dashboard.html";
+        // Redirect to the appropriate dashboard based on role
+        const dashboard = profile.role === "developer"
+          ? "developer-dashboard.html"
+          : "contractor-dashboard.html";
+        window.location.href = dashboard;
       } catch (err) {
         console.error(err);
         showAlert("error", "Unexpected error. Please try again.");


### PR DESCRIPTION
## Summary
- Redirect logged-in users to role-specific dashboards
- Add placeholder dashboards for contractors and developers with ad slots

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4efd72878832b9789bb9466f79abc