### PR TITLE
Add role-based login redirect

### DIFF
--- a/login.html
+++ b/login.html
@@ -223,9 +223,10 @@
         // ✅ Success
         showAlert("success", `Welcome back, ${profile.role}! You’re cleared for access.`);
 
-        // TODO: Redirect to role dashboard once built
-        // if (profile.role === "developer") window.location.href = "developer-dashboard.html";
-        // else window.location.href = "contractor-dashboard.html";
+        if (profile.role === "contractor")
+          window.location.href = "contractor-dashboard.html";
+        else if (profile.role === "developer")
+          window.location.href = "developer-dashboard.html";
       } catch (err) {
         console.error(err);
         showAlert("error", "Unexpected error. Please try again.");


### PR DESCRIPTION
## Summary
- Redirect users to contractor or developer dashboards based on profile role after login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be66ce5d4c832bbc38d5832e08e7a3