### PR TITLE
Handle contractor sign-up before application upload

### DIFF
--- a/contractor-signup.html
+++ b/contractor-signup.html
@@ -270,11 +270,13 @@
     if (typeof validate === "function" && !validate()) return;
 
     // Gather fields
+    const email = document.getElementById("email").value.trim();
+    const password = document.getElementById("password").value;
     const payload = {
       role: "contractor",
       full_name: document.getElementById("fullName").value.trim(),
       company_name: document.getElementById("companyName").value.trim(),
-      email: document.getElementById("email").value.trim(),
+      email,
       phone: document.getElementById("phone").value.trim(),
       trade: document.getElementById("trade").value,
       years_in_business: Number(document.getElementById("years").value || 0),
@@ -290,26 +292,39 @@
     const licenseFile = document.getElementById("license")?.files?.[0] || null;
 
     try {
+      // Sign up the contractor
+      const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          emailRedirectTo: "https://timelessfieldsolutions.com/login.html",
+          data: { role: "contractor" }
+        }
+      });
+      if (signUpError) throw signUpError;
+      const userId = signUpData?.user?.id || null;
+
       // 1) Try upload (will skip if no session)
       const up = await maybeUploadToApplicationsBucket(licenseFile);
       const license_url = up.path || null; // store path in applications.license_url
 
       // 2) Insert application
-      const { error } = await supabase.from("applications").insert([{
-        ...payload,
-        license_url  // ensure your table has this column
-      }]);
+      const { error } = await supabase.from("applications").insert([
+        {
+          ...payload,
+          user_id: userId,
+          license_url // ensure your table has this column
+        }
+      ]);
       if (error) throw error;
 
       // 3) UI success
       form.classList.add("hidden");
       successState.classList.remove("hidden");
-
-      if (up.skipped) {
-        showAlert("info", "Application received. You can upload documents after we approve and invite you to log in.");
-      } else {
-        showAlert("success", "Application received with your document. We’ll review it shortly.");
-      }
+      showAlert(
+        "success",
+        "Application received. Please check your email to confirm your account."
+      );
     } catch (err) {
       console.error(err);
       showAlert("error", err?.message || "Something went wrong. Try again.");


### PR DESCRIPTION
## Summary
- Sign up contractor with Supabase before processing uploads
- Attach user id and optional license URL when inserting application
- Inform applicants to check email for confirmation
- Redirect confirmation emails to production login page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be78b97da0832b9f115052bb0ac4f9