### PR TITLE
Use Supabase signUp flow on role-specific signup pages

### DIFF
--- a/contractor-signup.html
+++ b/contractor-signup.html
@@ -261,60 +261,67 @@
     return { path: data.path, skipped: false };
   }
 
-  /* 5) Submit → insert application row (and optional file) */
-  form.addEventListener("submit", async (e) => {
-    e.preventDefault();
-    clearAlert();
+    /* 5) Submit → sign up, create profile, optional application */
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      clearAlert();
 
-    // If you kept your existing validate(), call it here:
-    if (typeof validate === "function" && !validate()) return;
+      if (typeof validate === "function" && !validate()) return;
 
-    // Gather fields
-    const payload = {
-      role: "contractor",
-      full_name: document.getElementById("fullName").value.trim(),
-      company_name: document.getElementById("companyName").value.trim(),
-      email: document.getElementById("email").value.trim(),
-      phone: document.getElementById("phone").value.trim(),
-      trade: document.getElementById("trade").value,
-      years_in_business: Number(document.getElementById("years").value || 0),
-      service_zips: document.getElementById("zips").value.split(",").map(s => s.trim()).filter(Boolean)
-      // add your vetting fields here if you included them in the HTML:
-      // years_band: document.getElementById("yearsBand")?.value || null,
-      // proof_method: document.getElementById("proofMethod")?.value || null,
-      // proof_value: document.getElementById("proofValue")?.value || null,
-      // notes: document.getElementById("notes")?.value?.trim() || null,
-      // attest: !!document.getElementById("attest")?.checked,
-    };
+      const email = document.getElementById("email").value.trim();
+      const password = document.getElementById("password").value;
 
-    const licenseFile = document.getElementById("license")?.files?.[0] || null;
+      const payload = {
+        role: "contractor",
+        full_name: document.getElementById("fullName").value.trim(),
+        company_name: document.getElementById("companyName").value.trim(),
+        phone: document.getElementById("phone").value.trim(),
+        trade: document.getElementById("trade").value,
+        years_in_business: Number(document.getElementById("years").value || 0),
+        service_zips: document.getElementById("zips").value.split(",").map(s => s.trim()).filter(Boolean)
+      };
 
-    try {
-      // 1) Try upload (will skip if no session)
-      const up = await maybeUploadToApplicationsBucket(licenseFile);
-      const license_url = up.path || null; // store path in applications.license_url
+      const licenseFile = document.getElementById("license")?.files?.[0] || null;
 
-      // 2) Insert application
-      const { error } = await supabase.from("applications").insert([{
-        ...payload,
-        license_url  // ensure your table has this column
-      }]);
-      if (error) throw error;
+      try {
+        const { data: { user }, error: signUpError } = await supabase.auth.signUp({ email, password });
+        if (signUpError) {
+          if (signUpError.status === 422) {
+            showAlert("error", "That email is already registered. Please log in or reset your password.");
+            return;
+          }
+          throw signUpError;
+        }
 
-      // 3) UI success
-      form.classList.add("hidden");
-      successState.classList.remove("hidden");
+        const up = await maybeUploadToApplicationsBucket(licenseFile);
+        const license_url = up.path || null;
 
-      if (up.skipped) {
-        showAlert("info", "Application received. You can upload documents after we approve and invite you to log in.");
-      } else {
-        showAlert("success", "Application received with your document. We’ll review it shortly.");
+        const { error: profileError } = await supabase.from("profiles").insert([{
+          id: user.id,
+          role: "contractor",
+          status: "pending",
+          is_paid: false,
+          ...payload
+        }]);
+        if (profileError) throw profileError;
+
+        const { error: appError } = await supabase.from("applications").insert([{
+          user_id: user.id,
+          ...payload,
+          email,
+          license_url
+        }]);
+        if (appError) throw appError;
+
+        form.classList.add("hidden");
+        successState.classList.remove("hidden");
+
+        showAlert("success", "Account created. Your profile is pending approval.");
+      } catch (err) {
+        console.error(err);
+        showAlert("error", err?.message || "Something went wrong. Try again.");
       }
-    } catch (err) {
-      console.error(err);
-      showAlert("error", err?.message || "Something went wrong. Try again.");
-    }
-  });
+    });
 
   // Optional: role prefill
   try {

--- a/developer-signup.html
+++ b/developer-signup.html
@@ -287,54 +287,64 @@
         return ok;
     }
 
-    /* 4) Real submit → Supabase */
+    /* 4) Real submit → sign up, profile, optional application */
     form.addEventListener("submit", async (e) => {
         e.preventDefault();
         if (!validate()) return;
 
-        // Build payload from form
+        const email = document.getElementById("email").value.trim();
+        const password = document.getElementById("password").value;
+
         const payload = {
-        fullName: document.getElementById("fullName").value.trim(),
-        companyName: document.getElementById("companyName").value.trim(),
-        email: document.getElementById("email").value.trim(),
+        full_name: document.getElementById("fullName").value.trim(),
+        company_name: document.getElementById("companyName").value.trim(),
         phone: document.getElementById("phone").value.trim(),
-        // NOTE: DO NOT store this password in applications; real account is created on approval via Supabase invite
-        projectType: document.getElementById("projectType").value,
-        projectZips: document.getElementById("zips").value.trim().split(",").map(s => s.trim()),
-        proofFile: document.getElementById("proof").files[0] || null,
+        project_type: document.getElementById("projectType").value,
+        project_zips: document.getElementById("zips").value.trim().split(",").map(s => s.trim()),
         website: document.getElementById("website").value.trim() || null,
         linkedin: document.getElementById("linkedin").value.trim() || null
         };
+        const proofFile = document.getElementById("proof").files[0] || null;
 
         try {
-        // Optional file upload
+        const { data: { user }, error: signUpError } = await supabase.auth.signUp({ email, password });
+        if (signUpError) {
+            if (signUpError.status === 422) {
+            showAlert("error", "That email is already registered. Please log in or reset your password.");
+            return;
+            }
+            throw signUpError;
+        }
+
         let proof_filename = null;
-        if (USE_STORAGE && payload.proofFile) {
-            const fileName = `incoming/${crypto.randomUUID()}_${payload.proofFile.name}`;
-            const { error: upErr } = await supabase.storage.from("applications").upload(fileName, payload.proofFile);
+        if (USE_STORAGE && proofFile) {
+            const fileName = `incoming/${crypto.randomUUID()}_${proofFile.name}`;
+            const { error: upErr } = await supabase.storage.from("applications").upload(fileName, proofFile);
             if (upErr) throw upErr;
             proof_filename = fileName;
         }
 
-        // Insert application row
-        const { error } = await supabase.from("applications").insert([{
+        const { error: profileError } = await supabase.from("profiles").insert([{
+            id: user.id,
             role: "developer",
-            full_name: payload.fullName,
-            company_name: payload.companyName,
-            email: payload.email,
-            phone: payload.phone,
-            project_type: payload.projectType,
-            project_zips: payload.projectZips,
-            website: payload.website,
-            linkedin: payload.linkedin,
+            status: "pending",
+            is_paid: false,
+            ...payload
+        }]);
+        if (profileError) throw profileError;
+
+        const { error: appError } = await supabase.from("applications").insert([{
+            user_id: user.id,
+            role: "developer",
+            email,
+            ...payload,
             proof_filename
         }]);
-        if (error) throw error;
+        if (appError) throw appError;
 
-        // Success UI
         form.classList.add("hidden");
         successState.classList.remove("hidden");
-        showAlert("success", "Application received. We’ll review it shortly.");
+        showAlert("success", "Account created. Your profile is pending approval.");
 
         } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- create user accounts with `supabase.auth.signUp` in contractor and developer signups
- insert new rows into `profiles` with pending status and optional `applications` review data
- handle existing email errors and display pending approval message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbcc356c4832b8b9c1c765e35f5f6